### PR TITLE
Simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/profiling-approvers @open-telemetry/profiling-maintainers
+* @open-telemetry/profiling-approvers


### PR DESCRIPTION
@open-telemetry/profiling-maintainers is a child team of @open-telemetry/profiling-approvers, so no need to specify both here

here's a bit about the team structure: https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#collaborators-and-teams