### PR TITLE
profcheck: refactor code

### DIFF
--- a/tools/profcheck/check.go
+++ b/tools/profcheck/check.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package profcheck
 
 import (
 	"errors"

--- a/tools/profcheck/check_test.go
+++ b/tools/profcheck/check_test.go
@@ -1,4 +1,4 @@
-package main
+package profcheck
 
 import (
 	"errors"

--- a/tools/profcheck/cmd/profcheck/main.go
+++ b/tools/profcheck/cmd/profcheck/main.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/open-telemetry/sig-profiling/tools/profcheck"
+
 	profiles "go.opentelemetry.io/proto/otlp/profiles/v1development"
 	"google.golang.org/protobuf/proto"
 )
@@ -50,7 +52,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := (ConformanceChecker{CheckDictionaryDuplicates: *checkDupes, CheckSampleTimestampShape: *checkSampleShapes}).Check(&data); err != nil {
+	if err := (profcheck.ConformanceChecker{CheckDictionaryDuplicates: *checkDupes, CheckSampleTimestampShape: *checkSampleShapes}).Check(&data); err != nil {
 		fmt.Printf("%s: conformance checks failed: %v\n", inputPath, err)
 	}
 	fmt.Printf("%s: conformance checks passed\n", inputPath)

--- a/tools/profcheck/go.mod
+++ b/tools/profcheck/go.mod
@@ -1,4 +1,4 @@
-module profcheck
+module github.com/open-telemetry/sig-profiling/tools/profcheck
 
 go 1.24.4
 

--- a/tools/profcheck/go.sum
+++ b/tools/profcheck/go.sum
@@ -1,12 +1,8 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-go.opentelemetry.io/proto/otlp v1.8.0 h1:fRAZQDcAFHySxpJ1TwlA1cJ4tvcrw7nXl9xWWC8N5CE=
-go.opentelemetry.io/proto/otlp v1.8.0/go.mod h1:tIeYOeNBU4cvmPqpaji1P+KbB4Oloai8wN4rWzRrFF0=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.opentelemetry.io/proto/otlp/profiles/v1development v0.2.0 h1:yXinc284C6bmzA1r9jk7MxAhrBIIOH3qwmqwBmylZrA=
 go.opentelemetry.io/proto/otlp/profiles/v1development v0.2.0/go.mod h1:ygxocDWPB6Y6bySAjxmHyTebjAJ8jcEUAZc03gu1pxk=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=


### PR DESCRIPTION
Refactor code so it can be used as standalone executable but also imported as dependency to run the validation.

FYI @open-telemetry/profiling-maintainers 