### PR TITLE
profcheck: use dedicated check for AttributeTable

### DIFF
--- a/profcheck/check.go
+++ b/profcheck/check.go
@@ -330,7 +330,7 @@ func (c ConformanceChecker) checkStringTable(strTable []string) error {
 
 func (c ConformanceChecker) checkAttributeTable(attrTable []*profiles.KeyValueAndUnit, lenStrTable int) error {
 	var errs error
-	if err := checkZeroVal(attrTable); err != nil {
+	if err := checkAttributeTableZeroVal(attrTable); err != nil {
 		errs = errors.Join(errs, err)
 	}
 	for pos, kvu := range attrTable {
@@ -344,6 +344,25 @@ func (c ConformanceChecker) checkAttributeTable(attrTable []*profiles.KeyValueAn
 	// TODO: Add optional uniqueness check.
 	// TODO: Add optional unreferenced entries check.
 	return errs
+}
+
+// checkAttributeTableZeroVal verifies that the AttributeTable meets Profiles
+// dictionary conventions: the slice is not empty and the first entry has zero
+// key and unit indices and the value field holds nil as value.
+func checkAttributeTableZeroVal(attrTable []*profiles.KeyValueAndUnit) error {
+	if len(attrTable) == 0 {
+		return errors.New("empty table, must have at least zero value entry")
+	}
+	first := attrTable[0]
+	if first.KeyStrindex != 0 || first.UnitStrindex != 0 {
+		return fmt.Errorf("first attribute must have zero key/unit indices, got KeyStrindex=%d, UnitStrindex=%d",
+			first.KeyStrindex, first.UnitStrindex)
+	}
+	value := first.GetValue()
+	if value != nil && value.Value != nil {
+		return fmt.Errorf("first attribute value must be nil, got %v", value)
+	}
+	return nil
 }
 
 func (c ConformanceChecker) checkStackTable(stackTable []*profiles.Stack, lenLocTable int) error {


### PR DESCRIPTION
As KeyValueAndUnit uses pcommon.AnyValue as type for field Value we need to explicitly check the value of pcommon.AnyValue if it is nil rather than check if Value of KeyValueAndUnit is nil.

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/1360 and avoid the need for work arounds in various places.