### PR TITLE
Add Florian Lehner  to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 - [Dmitry Filimonov](https://github.com/petethepig), Pyroscope/Grafana
 - [Jonathan Halliday](https://github.com/jhalliday), Red Hat
 - [Christos Kalkanis](https://github.com/christos68k), Elastic
+- [Florian Lehner](https://github.com/florianl), Elastic
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ## Approvers
 
 - [Alexey Alexandrov](https://github.com/aalexand), Google
-- [Florian Lehner](https://github.com/florianl), Elastic
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).


### PR DESCRIPTION
I'm opening this PR to nominate Florian Lehner for addition to the https://github.com/orgs/open-telemetry/teams/profiling-maintainers group. 

Florian has been involved with OpenTelemetry profiling since the early days, regularly attends our SIG meetings and is a member of https://github.com/orgs/open-telemetry/teams/profiling-approvers with significant contributions including code reviews.

CC: @florianl @open-telemetry/profiling-maintainers @tigrannajaryan 