### PR TITLE
profcheck: add single value check for shape if timestamp is not set

### DIFF
--- a/profcheck/check.go
+++ b/profcheck/check.go
@@ -145,6 +145,9 @@ func (c ConformanceChecker) checkSample(s *profiles.Sample, startUnixNano uint64
 		}
 		shape = SampleShapeBoth
 	} else if hasValues {
+		if len(s.Values) != 1 {
+			errs = errors.Join(errs, fmt.Errorf("values (len=%d) must contain a single element if timestamps_unix_nano is not set", len(s.Values)))
+		}
 		shape = SampleShapeValuesOnly
 	} else if hasTimestamps {
 		shape = SampleShapeTimestampsOnly

--- a/profcheck/check_test.go
+++ b/profcheck/check_test.go
@@ -239,6 +239,21 @@ func TestCheckConformance(t *testing.T) {
 		},
 		wantErr: "",
 	}, {
+		desc: "sample with multiple values",
+		data: &profiles.ProfilesData{
+			Dictionary: zeroDictionary,
+			ResourceProfiles: []*profiles.ResourceProfiles{{
+				ScopeProfiles: []*profiles.ScopeProfiles{{
+					Profiles: []*profiles.Profile{{
+						Samples: []*profiles.Sample{{
+							Values: []int64{1, 2, 3},
+						}},
+					}},
+				}},
+			}},
+		},
+		wantErr: "must contain a single element if timestamps_unix_nano is not set",
+	}, {
 		desc: "sample with timestamps only",
 		data: &profiles.ProfilesData{
 			Dictionary: zeroDictionary,


### PR DESCRIPTION
This follows the improvements in the signal with
https://github.com/open-telemetry/opentelemetry-proto/pull/811.