### PR TITLE
profcheck: do values/timestamp check on samples only if configured

### DIFF
--- a/profcheck/check.go
+++ b/profcheck/check.go
@@ -106,6 +106,7 @@ const (
 	SampleShapeValuesOnly                 // Values only, no timestamps
 	SampleShapeTimestampsOnly             // Timestamps only, no explicit values.
 	SampleShapeBoth                       // Both timestamps and values, as parallel arrays.
+	SampleShapeInvalid                    // Unrecognized sample shape
 )
 
 func (s SampleShape) String() string {
@@ -138,6 +139,10 @@ func (c ConformanceChecker) checkSample(s *profiles.Sample, startUnixNano uint64
 		}
 	}
 
+	if !c.CheckSampleTimestampShape {
+		return errs
+	}
+
 	var shape SampleShape
 	if hasValues, hasTimestamps := len(s.Values) > 0, len(s.TimestampsUnixNano) > 0; hasValues && hasTimestamps {
 		if len(s.Values) != len(s.TimestampsUnixNano) {
@@ -150,15 +155,15 @@ func (c ConformanceChecker) checkSample(s *profiles.Sample, startUnixNano uint64
 		shape = SampleShapeTimestampsOnly
 	} else {
 		errs = errors.Join(errs, errors.New("sample must have at least one values or timestamps_unix_nano entry"))
-		shape = SampleShapeUnspecified
+		shape = SampleShapeInvalid
 	}
-	if c.CheckSampleTimestampShape && shape != SampleShapeUnspecified {
-		if *expectedShape == SampleShapeUnspecified {
-			*expectedShape = shape
-		} else if shape != *expectedShape {
-			errs = errors.Join(errs, fmt.Errorf("sample shape %s does not match expected sample shape %s", shape, expectedShape))
-		}
+
+	if *expectedShape == SampleShapeUnspecified {
+		*expectedShape = shape
+	} else if shape != *expectedShape {
+		errs = errors.Join(errs, fmt.Errorf("sample shape %s does not match expected sample shape %s", shape, expectedShape))
 	}
+
 	return errs
 }
 

--- a/profcheck/check_test.go
+++ b/profcheck/check_test.go
@@ -204,7 +204,8 @@ func TestCheckConformance(t *testing.T) {
 				}},
 			}},
 		},
-		wantErr: "sample must have at least one values or timestamps_unix_nano entry",
+		checkSampleShapes: true,
+		wantErr:           "sample must have at least one values or timestamps_unix_nano entry",
 	}, {
 		desc: "sample with values and timestamps length mismatch",
 		data: &profiles.ProfilesData{
@@ -222,7 +223,8 @@ func TestCheckConformance(t *testing.T) {
 				}},
 			}},
 		},
-		wantErr: "values (len=1) and timestamps_unix_nano (len=2) must contain the same number of elements",
+		checkSampleShapes: true,
+		wantErr:           "values (len=1) and timestamps_unix_nano (len=2) must contain the same number of elements",
 	}, {
 		desc: "sample with values only",
 		data: &profiles.ProfilesData{
@@ -237,7 +239,8 @@ func TestCheckConformance(t *testing.T) {
 				}},
 			}},
 		},
-		wantErr: "",
+		checkSampleShapes: true,
+		wantErr:           "",
 	}, {
 		desc: "sample with timestamps only",
 		data: &profiles.ProfilesData{
@@ -254,6 +257,7 @@ func TestCheckConformance(t *testing.T) {
 				}},
 			}},
 		},
+		checkSampleShapes: true,
 		wantErr: "",
 	}, {
 		desc: "sample with values and timestamps matching",
@@ -272,6 +276,7 @@ func TestCheckConformance(t *testing.T) {
 				}},
 			}},
 		},
+		checkSampleShapes: true,
 		wantErr: "",
 	}, {
 		desc: "mixed sample types",

--- a/profcheck/check_test.go
+++ b/profcheck/check_test.go
@@ -258,7 +258,7 @@ func TestCheckConformance(t *testing.T) {
 			}},
 		},
 		checkSampleShapes: true,
-		wantErr: "",
+		wantErr:           "",
 	}, {
 		desc: "sample with values and timestamps matching",
 		data: &profiles.ProfilesData{
@@ -277,7 +277,7 @@ func TestCheckConformance(t *testing.T) {
 			}},
 		},
 		checkSampleShapes: true,
-		wantErr: "",
+		wantErr:           "",
 	}, {
 		desc: "mixed sample types",
 		data: &profiles.ProfilesData{
@@ -289,6 +289,28 @@ func TestCheckConformance(t *testing.T) {
 						DurationNano: 10,
 						Samples: []*profiles.Sample{{
 							Values: []int64{1},
+						}, {
+							TimestampsUnixNano: []uint64{100},
+						}},
+					}},
+				}},
+			}},
+		},
+		checkSampleShapes: true,
+		wantErr:           "does not match expected sample shape",
+	}, {
+		desc: "mixed sample types without values",
+		data: &profiles.ProfilesData{
+			Dictionary: zeroDictionary,
+			ResourceProfiles: []*profiles.ResourceProfiles{{
+				ScopeProfiles: []*profiles.ScopeProfiles{{
+					Profiles: []*profiles.Profile{{
+						TimeUnixNano: 100,
+						DurationNano: 10,
+						Samples: []*profiles.Sample{{
+							Values: []int64{1},
+						}, {
+							// Sample without Values and/or Timestamps
 						}, {
 							TimestampsUnixNano: []uint64{100},
 						}},


### PR DESCRIPTION
Ignore the validation of values and timestamps in samples, if not configured to do so.