### PR TITLE
CI: run profcheck tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+
+# Set default permissions as read only.
+permissions: read-all
+
+name: profcheck
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-latest]
+        go-version: ['oldstable', 'stable']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Clone code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: go.sum
+          check-latest: true
+      - name: tests
+        run: |
+          go test -C profcheck/ ./...

--- a/profcheck/check_test.go
+++ b/profcheck/check_test.go
@@ -255,7 +255,8 @@ func TestCheckConformance(t *testing.T) {
 				}},
 			}},
 		},
-		wantErr: "must contain a single element if timestamps_unix_nano is not set",
+		checkSampleShapes: true,
+		wantErr:           "must contain a single element if timestamps_unix_nano is not set",
 	}, {
 		desc: "sample with timestamps only",
 		data: &profiles.ProfilesData{


### PR DESCRIPTION
Tests in `profcheck` do fail with recent changes:

```
--- FAIL: TestCheckConformance (0.00s)
    --- FAIL: TestCheckConformance/sample_with_multiple_values (0.00s)
        check_test.go:368: Check(): got no error, want error containing "must contain a single element if timestamps_unix_nano is not set"
FAIL
FAIL	github.com/open-telemetry/sig-profiling/profcheck	0.005s
?   	github.com/open-telemetry/sig-profiling/profcheck/cmd/profcheck	[no test files]
```

I didn't notice this issue due to caching issues. To prevent such issues in the future, add a CI job that runs profcheck tests. 